### PR TITLE
pycountry fix

### DIFF
--- a/utils/select.py
+++ b/utils/select.py
@@ -21,7 +21,7 @@ Backgrounds = [
 
 BackgroundKeys = [x[0] for x in Backgrounds]
 
-Countries = [(country.alpha3, country.name) for country in pycountry.countries]
+Countries = [(country.alpha_3, country.name) for country in pycountry.countries]
 Countries = (sorted(Countries, key=lambda x: "0" if x[1] == "Iceland" else x[1]))
 CountryKeys = [x[0] for x in Countries]
 


### PR DESCRIPTION
Hi there,

apparently the pycountry API has changed since 2016. Running the current code yielded an AttributeError
```
$ ./venv/bin/python3 app.py 
Traceback (most recent call last):
  File "app.py", line 9, in <module>
    from utils import misc, select
  File "/usr/home/scoring/ColdCore/utils/select.py", line 24, in <module>
    Countries = [(country.alpha3, country.name) for country in pycountry.countries]
  File "/usr/home/scoring/ColdCore/utils/select.py", line 24, in <listcomp>
    Countries = [(country.alpha3, country.name) for country in pycountry.countries]
  File "/usr/home/scoring/ColdCore/venv/lib/python3.5/site-packages/pycountry/db.py", line 22, in __getattr__
    raise AttributeError
```
so I fixed it to make it work.

Cheers,
tpltnt